### PR TITLE
dialog: Improve ADDialog matches

### DIFF
--- a/metadata/dialog.xml.in
+++ b/metadata/dialog.xml.in
@@ -12,7 +12,7 @@
 				<option name="dialogtypes" type="match">
 					<_short>Dialog Match</_short>
 					<_long>Dialogs which will trigger fading</_long>
-				    <default>(override_redirect=0) &amp; !(type=Menu | class=Gimp | class=Inkscape | (class=Firefox &amp; type=Tooltip)) &amp; !type=Tooltip</default>
+				    <default>(override_redirect=0) &amp; !( class=Firefox &amp; type=Utility ) &amp; !(class=plasmashell) &amp; !(type=Menu | class=Gimp | class=Inkscape | (class=Firefox &amp; type=Tooltip)) &amp; !type=Tooltip</default>
 				</option>
 				<option name="speed" type="float">
 					<_short>Speed</_short>


### PR DESCRIPTION
This improves the ADDialog matching by excluding:
- Plasma (some of these (in the Desktop Settings dialog) would be OK to match, but the
    default behavior is rather broken, and this resolves the most egregious problem of
    system menu submenus dimming the enclosing menu; I'm not sure how to correctly match
    the Desktop Settings dialog, and it's not significant enough to me to take more time
    to)
- Firefox Utility windows (e.g. the popups provided by the "Tab Scope" extension)