### PR TITLE
boing: Add to makefiles; add XML; default enabled

### DIFF
--- a/metadata/Makefile.am
+++ b/metadata/Makefile.am
@@ -75,6 +75,7 @@ endif
 
 xml_in_files =               \
 	anaglyph.xml.in       \
+	boing.xml.in          \
 	dialog.xml.in         \
 	fakeargb.xml.in       \
 	fireflies.xml.in      \

--- a/metadata/boing.xml.in
+++ b/metadata/boing.xml.in
@@ -1,0 +1,145 @@
+<?xml version="1.0"?>
+<compiz>
+	<plugin name="boing" useBcop="true">
+		<_short>Boing</_short>
+		<_long>Boing for Compiz</_long>
+		<category>Extras</category>
+		<deps>
+			<relation type="after">
+				<plugin>png</plugin>
+				<plugin>svg</plugin>
+				<plugin>jpeg</plugin>
+			</relation>
+		</deps>
+		<display>
+			<group>
+				<_short>Settings</_short>
+				<option name="num_leaves" type="int">
+					<_short>Number Of balls</_short>
+					<_long>Number of balls</_long>
+					<default>16</default>
+					<min>0</min>
+					<max>10000</max>
+				</option>
+				<option name="leaf_size" type="float">
+					<_short>Size Of balls</_short>
+					<_long>Size of balls</_long>
+					<default>100.0</default>
+					<min>0.0</min>
+					<max>100.0</max>
+					<precision>0.1</precision>
+				</option>
+				<option name="autumn_update_delay" type="int">
+					<_short>Update Delay</_short>
+					<_long>Delay (in ms) between screen updates. Decreasing this value may make leaves fall more smoothly, but will also increase CPU usage.</_long>
+					<default>21</default>
+					<min>10</min>
+					<max>200</max>
+				</option>
+				<option name="screen_boxing" type="int">
+					<_short>Screen Boxing</_short>
+					<_long>How far outside the screen resolution leaves can be before being removed. Needed because of FOV.</_long>
+					<default>400</default>
+					<min>-2000</min>
+					<max>2000</max>
+				</option>
+				<option name="screen_depth" type="int">
+					<_short>Screen Depth</_short>
+					<_long>How deep into the screen leaves can be drawn before being removed</_long>
+					<default>1000</default>
+					<min>0</min>
+					<max>2000</max>
+				</option>
+				<option name="leaves_over_windows" type="bool">
+					<_short>Balls Over Windows</_short>
+					<_long>Balls are drawn above windows</_long>
+					<default>false</default>
+				</option>
+				<option name="leaf_rotation" type="bool">
+					<_short>Rotate Balls</_short>
+					<_long>Balls rotate if checked.</_long>
+					<default>false</default>
+				</option>
+				<option name="wind_direction" type="int">
+					<_short>Wind Direction</_short>
+					<_long>Select the wind direction</_long>
+					<default>0</default>
+					<min>0</min>
+					<max>3</max>
+					<desc>
+						<value>0</value>
+						<_name>No Wind</_name>
+					</desc>
+					<desc>
+						<value>1</value>
+						<_name>Up</_name>
+					</desc>
+					<desc>
+						<value>2</value>
+						<_name>Left</_name>
+					</desc>
+					<desc>
+						<value>3</value>
+						<_name>Right</_name>
+					</desc>
+				</option>
+			</group>
+			<group>
+				<_short>Textures</_short>
+				<option name="leaf_textures" type="list">
+					<_short>Ball Textures</_short>
+					<_long>Ball textures</_long>
+					<hints>file;image;</hints>
+					<type>string</type>
+					<default>
+					<value>boing/ball-00.png</value>
+					<value>boing/ball-01.png</value>
+					<value>boing/ball-02.png</value>
+					<value>boing/ball-03.png</value>
+					<value>boing/ball-04.png</value>
+					<value>boing/ball-05.png</value>
+					<value>boing/ball-06.png</value>
+					<value>boing/ball-07.png</value>
+					<value>boing/ball-08.png</value>
+					<value>boing/ball-09.png</value>
+					<value>boing/ball-10.png</value>
+					<value>boing/ball-11.png</value>
+					<value>boing/ball-12.png</value>
+					<value>boing/ball-13.png</value>
+					<value>boing/ball-14.png</value>
+					<value>boing/ball-15.png</value>
+					</default>
+				</option>
+				<option name="default_enabled" type="bool">
+					<_short>Enable by default</_short>
+					<_long>Enable boing by default.</_long>
+					<default>false</default>
+				</option>
+			</group>
+			<group>
+				<_short>Debug</_short>
+				<option name="use_blending" type="bool">
+					<_short>Enable Blending</_short>
+					<_long>Enables alpha blending of balls.</_long>
+					<default>true</default>
+				</option>
+				<option name="use_textures" type="bool">
+					<_short>Enable Textures</_short>
+					<_long>Enables textured balls. If not selected, color gradients are used.</_long>
+					<default>true</default>
+				</option>
+			</group>
+			<group>
+				<_short>Key Bindings</_short>
+				<option name="toggle_key" type="key">
+					<_short>Toggle Boing</_short>
+					<_long>Boing toggle key</_long>
+					<allowed key="true"/>
+					<default>
+						<key>&lt;Super&gt;F11</key>
+					</default>
+				</option>
+			</group>
+		</display>
+	</plugin>
+</compiz>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -4,6 +4,7 @@ metadata/anaglyph.xml.in
 metadata/animationplus.xml.in
 metadata/animationsim.xml.in
 metadata/atlantis.xml.in
+metadata/boing.xml.in
 metadata/cubemodel.xml.in
 metadata/dialog.xml.in
 metadata/earth.xml.in

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -3,6 +3,7 @@
 SUBDIRS =                \
 	anaglyph          \
 	atlantis          \
+	boing             \
 	cubemodel         \
 	dialog            \
 	earth             \

--- a/src/boing/boing.c
+++ b/src/boing/boing.c
@@ -31,11 +31,8 @@
  * for helping me make this possible
  */
 
-#include <math.h>
-
 #include <compiz-core.h>
 #include "boing_options.h"
-#include <time.h>
 
 
 #define GET_BOING_DISPLAY(d)                            \
@@ -748,6 +745,7 @@ boingInitDisplay (CompPlugin  *p,
     boingSetLeafSizeNotify (d, boingDisplayOptionChanged);
     boingSetAutumnUpdateDelayNotify (d, boingDisplayOptionChanged);
     boingSetLeafTexturesNotify (d, boingDisplayOptionChanged);
+    boingSetDefaultEnabledNotify (d, boingDisplayOptionChanged);
 
     texOpt = boingGetLeafTexturesOption (d);
     sd->boingTexFiles = texOpt->value.list.value;


### PR DESCRIPTION
This commit
- adds boing to the makefiles it was missing from
- adds the missing boing.xml.in metadata file
- merges remaining changes from @matijaskala's repo
  (adds default-enabled notify and removes unused
  imports)