### PR TITLE
 Rotation and  south-on-top option 

### DIFF
--- a/metadata/earth.xml.in
+++ b/metadata/earth.xml.in
@@ -50,6 +50,14 @@
 				<_long>Download a cloudmap every 3 hour</_long>
 				<default>false</default>
 			</option>
+			<option name="rotation" type="float">
+				<_short>Rotation speed</_short>
+				<_long>Make the whole scene rotate</_long>
+				<min>-1</min>
+				<max>1</max>
+				<default>0</default>
+				<precision>0.001</precision>
+			</option>
 			<option name="clouds_url" type="string">
 				<_short>Realtime cloudmap url</_short>
 				<_long>Url from which realtime cloudmap texture will be downloaded</_long>

--- a/metadata/earth.xml.in
+++ b/metadata/earth.xml.in
@@ -63,6 +63,11 @@
 				<_long>Url from which realtime cloudmap texture will be downloaded</_long>
 				<default>http://home.megapass.co.kr/~holywatr/cloud_data/clouds_2048.jpg</default>
 			</option>
+			<option name="south_on_top" type="bool">
+				<_short>Switch the poles</_short>
+				<_long>Switch the north and south pole</_long>
+				<default>false</default>
+			</option>
 			<option name="earth_size" type="float">
 				<_short>Earth size</_short>
 				<_long>Size of earth</_long>

--- a/src/earth/earth.c
+++ b/src/earth/earth.c
@@ -637,8 +637,15 @@ earthPaintInside (CompScreen			  *s,
 	glRotatef ((360.0f / s->nOutputDev) * output->id, 0, 1, 0);
 
 	/* Earth position according to longitude and latitude */
-	glRotatef (es->lat - 90, 1, 0, 0);
+	if (earthGetSouthOnTop (s)) {
+	glRotatef (-es->lat-90, 1, 0, 0);
+	glRotatef (-es->lon, 0, 0, 1);
+	glRotatef (180, 0, 1, 0);
+	}
+	else {
+	glRotatef (es->lat-90, 1, 0, 0);
 	glRotatef (es->lon, 0, 0, 1);
+	}
 
 	glPushMatrix ();
 
@@ -740,7 +747,16 @@ earthClearTargetOutput (CompScreen *s,
 	/* Rotate the skydome according to the mouse and the rotation of the Earth */
 	glRotatef (vRotate - 90, 1.0f, 0.0f, 0.0f);
 	glRotatef (xRotate + es->rotation, 0.0f, 0.0f, 1.0f);
-    
+	if (earthGetSouthOnTop (s)) {
+	glRotatef (-es->lat, 1, 0, 0);
+	glRotatef (-es->lon + 180, 0, 0, 1);
+	glRotatef (180, 0, 1, 0);
+	}
+	else {
+	glRotatef (es->lat, 1, 0, 0);
+	glRotatef (es->lon + 180, 0, 0, 1);
+	}
+
 	if (cs->moMode == CUBE_MOMODE_MULTI)
 	glRotatef ((360.0f / s->nOutputDev) * currentoutput->id, 0, 0, 1);
 

--- a/src/earth/earth.c
+++ b/src/earth/earth.c
@@ -496,6 +496,9 @@ earthScreenOptionChanged (CompScreen		*s,
 	case EarthScreenOptionClouds:
 		es->clouds = earthGetClouds (s);
 	break;
+	case EarthScreenOptionRotation:
+		es->rotspeed    = earthGetRotation (s);
+	break;
 	case EarthScreenOptionCloudsUrl:
 		es->clouds_url_changed = TRUE;
 		es->cloudsthreaddata.url = earthGetCloudsUrl (s);
@@ -546,7 +549,14 @@ earthPreparePaintScreen (CompScreen *s,
 	es->gha = (float)currenttime->tm_hour-(es->tz +
 				(float)currenttime->tm_isdst) +
 				(float)currenttime->tm_min / 60.0f;
-
+				(float)currenttime->tm_sec/3600.0000f;
+	
+	/* Animation */
+	es->rotation += es->rotspeed;
+	if (es->rotation > 360)
+	es->rotation -= 360;
+	else if (es->rotation < -360)
+	es->rotation += 360;
 	/* Realtime cloudmap */
 	res = stat (es->cloudsfile.filename, &attrib);
 	if (es->clouds && (es->cloudsthreaddata.started == 0) &&
@@ -619,6 +629,12 @@ earthPaintInside (CompScreen			  *s,
 		ratio = (float)s->height / (float)s->width;
 	glScalef (ratio * es->earth_size, es->earth_size, ratio * es->earth_size);
 	es->previousoutput = output->id;
+
+	/* Animation */
+	glRotatef (es->rotation, 0, 1, 0);
+    
+	if (cs->moMode == CUBE_MOMODE_MULTI)
+	glRotatef ((360.0f / s->nOutputDev) * output->id, 0, 1, 0);
 
 	/* Earth position according to longitude and latitude */
 	glRotatef (es->lat - 90, 1, 0, 0);
@@ -723,7 +739,11 @@ earthClearTargetOutput (CompScreen *s,
 
 	/* Rotate the skydome according to the mouse and the rotation of the Earth */
 	glRotatef (vRotate - 90, 1.0f, 0.0f, 0.0f);
-	glRotatef (xRotate, 0.0f, 0.0f, 1.0f);
+	glRotatef (xRotate + es->rotation, 0.0f, 0.0f, 1.0f);
+    
+	if (cs->moMode == CUBE_MOMODE_MULTI)
+	glRotatef ((360.0f / s->nOutputDev) * currentoutput->id, 0, 0, 1);
+
 	glRotatef (es->lat, 1, 0, 0);
 	glRotatef (es->lon + 180, 0, 0, 1);
 
@@ -788,6 +808,9 @@ earthInitScreen (CompPlugin *p,
 
 	es->damage = FALSE;
 
+	/* Animation */
+	es->rotation = 0;
+    
 	/* Load texture images */
 	for (i = 0; i < 4; i++)
 	{
@@ -898,6 +921,7 @@ earthInitScreen (CompPlugin *p,
 	earthSetTimezoneNotify (s, earthScreenOptionChanged);
 	earthSetShadersNotify (s, earthScreenOptionChanged);
 	earthSetCloudsNotify (s, earthScreenOptionChanged);
+	earthSetRotationNotify (s, earthScreenOptionChanged);
 	earthSetCloudsUrlNotify (s, earthScreenOptionChanged);
 	earthSetEarthSizeNotify (s, earthScreenOptionChanged);
 

--- a/src/earth/earth.h
+++ b/src/earth/earth.h
@@ -118,6 +118,7 @@ typedef struct _EarthScreen
     float tz;
     Bool  shaders;
     Bool  clouds;
+    float rotspeed;
     Bool  clouds_url_changed;
     float earth_size;
 
@@ -125,6 +126,9 @@ typedef struct _EarthScreen
 
     /* Sun position */
     float dec, gha;
+
+    /* Animation */
+    float rotation;
 
     /* Threads */
     TexThreadData texthreaddata [4];


### PR DESCRIPTION
to http://cgit.compiz.org/~satamaxx/earth/commit/?id=b0cf3ab7452848569e5002b9df1266e85f51a995
author	Maxime Wack <maximewack@free.fr>

south-on-top option 
* add south_on_top configuration

* implement south_on_top support

* add south_on_top variable

* reread south_on_top setting on each redraw

* implement for skydome as well

* refactor